### PR TITLE
Add UI/UE feedback loop panel and responsive mobile navigation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4092,3 +4092,235 @@ body {
     font-size: 22px;
   }
 }
+
+/* UI Feedback Loop */
+.ui-feedback-loop {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 1000;
+}
+
+.feedback-fab {
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #e94560, #f39422);
+  color: #fff;
+  font-weight: 700;
+  padding: 12px 16px;
+  cursor: pointer;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.35);
+}
+
+.feedback-panel {
+  margin-top: 10px;
+  width: min(360px, 92vw);
+  background: rgba(15, 23, 42, 0.96);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.feedback-panel h3,
+.feedback-panel h4 {
+  margin: 0 0 8px;
+}
+
+.feedback-panel p {
+  margin: 0 0 10px;
+  font-size: 13px;
+  color: #cbd5e1;
+}
+
+.feedback-panel form {
+  display: grid;
+  gap: 8px;
+}
+
+.feedback-panel label {
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.feedback-panel select,
+.feedback-panel textarea {
+  width: 100%;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 8px;
+}
+
+.feedback-submit-btn {
+  border: none;
+  border-radius: 8px;
+  padding: 10px;
+  font-weight: 600;
+  background: #22c55e;
+  color: #fff;
+  cursor: pointer;
+}
+
+.feedback-list {
+  margin-top: 12px;
+  max-height: 260px;
+  overflow: auto;
+}
+
+.feedback-item {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid #334155;
+  border-left: 4px solid #64748b;
+  border-radius: 8px;
+  padding: 10px;
+  margin-bottom: 8px;
+}
+
+.feedback-item.priority-high { border-left-color: #ef4444; }
+.feedback-item.priority-medium { border-left-color: #f59e0b; }
+.feedback-item.priority-low { border-left-color: #22c55e; }
+
+.feedback-item-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.feedback-item button {
+  margin-top: 8px;
+  border: 1px solid #475569;
+  border-radius: 6px;
+  background: transparent;
+  color: #cbd5e1;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+
+.empty-hint {
+  font-style: italic;
+}
+
+.pro-loop .loop-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.pro-loop .loop-kpis {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.feedback-form-grid input,
+.feedback-form-grid textarea,
+.feedback-form-grid select {
+  width: 100%;
+}
+
+.feedback-row {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: 1fr 1fr;
+}
+
+.status-tabs {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.status-tabs button {
+  border: 1px solid #475569;
+  background: #0f172a;
+  color: #cbd5e1;
+  border-radius: 999px;
+  font-size: 12px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.status-tabs button.active {
+  border-color: #22c55e;
+  color: #22c55e;
+}
+
+.pro-item .meta {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.item-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* UX optimization: responsive navigation and spacing */
+.mobile-nav-toggle {
+  display: none;
+  margin: 12px auto 0;
+  padding: 8px 14px;
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.45);
+  color: #e2e8f0;
+  font-weight: 600;
+}
+
+.App-nav {
+  flex-wrap: wrap;
+}
+
+.App-content {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+}
+
+@media (max-width: 900px) {
+  .mobile-nav-toggle {
+    display: inline-block;
+  }
+
+  .App-nav {
+    display: none;
+    margin-top: 12px;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    max-width: 360px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .App-nav.open {
+    display: flex;
+  }
+
+  .App-nav .nav-btn {
+    width: 100%;
+  }
+
+  .user-menu {
+    display: grid;
+    gap: 8px;
+  }
+
+  .App-content {
+    padding: 16px;
+    gap: 16px;
+  }
+
+  .chat-section {
+    width: 100%;
+    max-width: 460px;
+  }
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import Multiplayer from "./Multiplayer";
 import Puzzles from "./Puzzles";
 import OpeningExplorer from "./OpeningExplorer";
 import { AuthProvider } from "./AuthContext";
+import UiFeedbackLoop from "./UiFeedbackLoop";
 import { onAuthChange, logout, isFirebaseConfigured } from "./firebase";
 
 // Valid routes
@@ -39,6 +40,7 @@ class AppContent extends Component {
     currentPage: getPageFromHash(),
     user: null,
     showLogin: false,
+    navOpen: false,
   };
 
   componentDidMount() {
@@ -61,13 +63,13 @@ class AppContent extends Component {
   handleHashChange = () => {
     const page = getPageFromHash();
     if (page !== this.state.currentPage) {
-      this.setState({ currentPage: page });
+      this.setState({ currentPage: page, navOpen: false });
     }
   };
 
   navigateTo = (page) => {
     setHashFromPage(page);
-    this.setState({ currentPage: page });
+    this.setState({ currentPage: page, navOpen: false });
   };
 
   handleLogout = async () => {
@@ -79,7 +81,7 @@ class AppContent extends Component {
   };
 
   render() {
-    const { currentPage, user, showLogin } = this.state;
+    const { currentPage, user, showLogin, navOpen } = this.state;
     const configured = isFirebaseConfigured();
 
     return (
@@ -87,7 +89,10 @@ class AppContent extends Component {
         <header className="App-header">
           <h1 className="App-title">Chess Arena</h1>
           <p className="App-subtitle">Play chess and chat with friends</p>
-          <nav className="App-nav">
+          <button className="mobile-nav-toggle" onClick={() => this.setState({ navOpen: !navOpen })}>
+            {navOpen ? "Close" : "Menu"}
+          </button>
+          <nav className={`App-nav ${navOpen ? "open" : ""}`}>
             <button
               className={`nav-btn ${currentPage === "game" ? "active" : ""}`}
               onClick={() => this.navigateTo("game")}
@@ -183,6 +188,8 @@ class AppContent extends Component {
             <Leaderboard onBack={() => this.navigateTo("game")} />
           </div>
         )}
+
+        <UiFeedbackLoop />
 
         {showLogin && (
           <Login

--- a/frontend/src/UiFeedbackLoop.js
+++ b/frontend/src/UiFeedbackLoop.js
@@ -1,0 +1,171 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+const STORAGE_KEY = "ui_ue_loop_v2";
+
+const CATEGORY_OPTIONS = ["视觉层", "交互层", "信息架构", "性能体验", "可访问性", "Bug"];
+const PRIORITY_OPTIONS = ["P0", "P1", "P2"];
+const STATUS_OPTIONS = ["Backlog", "In Progress", "Validated", "Shipped"];
+const EFFORT_OPTIONS = ["S", "M", "L"];
+
+const PRIORITY_WEIGHT = { P0: 3, P1: 2, P2: 1 };
+const EFFORT_WEIGHT = { S: 3, M: 2, L: 1 };
+
+const createEntry = (draft) => ({
+  id: `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  status: "Backlog",
+  ...draft,
+});
+
+const calcScore = (item) => {
+  const p = PRIORITY_WEIGHT[item.priority] || 1;
+  const e = EFFORT_WEIGHT[item.effort] || 1;
+  const confidence = Number(item.confidence || 0);
+  return p * e * confidence;
+};
+
+const rankItems = (items) =>
+  [...items].sort((a, b) => {
+    const scoreDiff = calcScore(b) - calcScore(a);
+    if (scoreDiff !== 0) return scoreDiff;
+    return new Date(b.updatedAt) - new Date(a.updatedAt);
+  });
+
+export default function UiFeedbackLoop() {
+  const [open, setOpen] = useState(false);
+  const [activeStatus, setActiveStatus] = useState("Backlog");
+  const [entries, setEntries] = useState([]);
+  const [draft, setDraft] = useState({
+    title: "",
+    insight: "",
+    category: CATEGORY_OPTIONS[0],
+    priority: "P1",
+    effort: "M",
+    confidence: 3,
+    metric: "CTR / 留存 / 时长",
+  });
+
+  useEffect(() => {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) setEntries(parsed);
+    } catch (error) {
+      console.error("Failed to parse UI/UE loop data", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  }, [entries]);
+
+  const board = useMemo(() => {
+    const grouped = STATUS_OPTIONS.reduce((acc, status) => ({ ...acc, [status]: [] }), {});
+    rankItems(entries).forEach((item) => grouped[item.status].push(item));
+    return grouped;
+  }, [entries]);
+
+  const stats = useMemo(() => {
+    const total = entries.length;
+    const validated = entries.filter((item) => item.status === "Validated" || item.status === "Shipped").length;
+    return {
+      total,
+      validated,
+      loopRate: total ? `${Math.round((validated / total) * 100)}%` : "0%",
+    };
+  }, [entries]);
+
+  const submit = (event) => {
+    event.preventDefault();
+    if (!draft.title.trim() || !draft.insight.trim()) return;
+    setEntries((prev) => [createEntry({ ...draft, title: draft.title.trim(), insight: draft.insight.trim() }), ...prev]);
+    setDraft((prev) => ({ ...prev, title: "", insight: "" }));
+    setActiveStatus("Backlog");
+    setOpen(true);
+  };
+
+  const updateStatus = (id, direction) => {
+    setEntries((prev) =>
+      prev.map((item) => {
+        if (item.id !== id) return item;
+        const index = STATUS_OPTIONS.indexOf(item.status);
+        const next = Math.max(0, Math.min(STATUS_OPTIONS.length - 1, index + direction));
+        return { ...item, status: STATUS_OPTIONS[next], updatedAt: new Date().toISOString() };
+      })
+    );
+  };
+
+  const archive = (id) => setEntries((prev) => prev.filter((item) => item.id !== id));
+
+  return (
+    <aside className="ui-feedback-loop" aria-label="Professional UI/UE loop">
+      <button className="feedback-fab" onClick={() => setOpen((v) => !v)}>
+        {open ? "关闭 UI/UE Loop" : "UI/UE Loop"}
+      </button>
+      {open && (
+        <section className="feedback-panel pro-loop">
+          <div className="loop-header">
+            <h3>UI / UE Engineering Loop</h3>
+            <div className="loop-kpis">
+              <span>总条目: {stats.total}</span>
+              <span>闭环率: {stats.loopRate}</span>
+            </div>
+          </div>
+
+          <form onSubmit={submit} className="feedback-form-grid">
+            <label>
+              问题标题
+              <input value={draft.title} onChange={(e) => setDraft((d) => ({ ...d, title: e.target.value }))} placeholder="例：移动端导航拥挤" />
+            </label>
+            <label>
+              观察洞察
+              <textarea value={draft.insight} onChange={(e) => setDraft((d) => ({ ...d, insight: e.target.value }))} rows={3} placeholder="现象 + 假设 + 预期提升" />
+            </label>
+            <div className="feedback-row">
+              <label>类别<select value={draft.category} onChange={(e) => setDraft((d) => ({ ...d, category: e.target.value }))}>{CATEGORY_OPTIONS.map((c) => <option key={c}>{c}</option>)}</select></label>
+              <label>优先级<select value={draft.priority} onChange={(e) => setDraft((d) => ({ ...d, priority: e.target.value }))}>{PRIORITY_OPTIONS.map((p) => <option key={p}>{p}</option>)}</select></label>
+            </div>
+            <div className="feedback-row">
+              <label>投入<select value={draft.effort} onChange={(e) => setDraft((d) => ({ ...d, effort: e.target.value }))}>{EFFORT_OPTIONS.map((e) => <option key={e}>{e}</option>)}</select></label>
+              <label>信心(1-5)<input type="number" min="1" max="5" value={draft.confidence} onChange={(e) => setDraft((d) => ({ ...d, confidence: Number(e.target.value) || 1 }))} /></label>
+            </div>
+            <label>验证指标<input value={draft.metric} onChange={(e) => setDraft((d) => ({ ...d, metric: e.target.value }))} /></label>
+            <button type="submit" className="feedback-submit-btn">创建实验卡片</button>
+          </form>
+
+          <div className="status-tabs">
+            {STATUS_OPTIONS.map((status) => (
+              <button key={status} className={activeStatus === status ? "active" : ""} onClick={() => setActiveStatus(status)}>
+                {status} ({board[status].length})
+              </button>
+            ))}
+          </div>
+
+          <div className="feedback-list">
+            {board[activeStatus].length === 0 ? (
+              <p className="empty-hint">当前状态无卡片，继续添加新的 UI/UE 假设。</p>
+            ) : (
+              board[activeStatus].map((item) => (
+                <article key={item.id} className="feedback-item pro-item">
+                  <div className="feedback-item-head">
+                    <strong>{item.title}</strong>
+                    <span>Score: {calcScore(item)}</span>
+                  </div>
+                  <p>{item.insight}</p>
+                  <p className="meta">{item.category} · {item.priority} · Effort {item.effort} · 指标: {item.metric}</p>
+                  <div className="item-actions">
+                    <button type="button" onClick={() => updateStatus(item.id, -1)}>← 回退</button>
+                    <button type="button" onClick={() => updateStatus(item.id, 1)}>推进 →</button>
+                    <button type="button" onClick={() => archive(item.id)}>归档</button>
+                  </div>
+                </article>
+              ))
+            )}
+          </div>
+        </section>
+      )}
+    </aside>
+  );
+}


### PR DESCRIPTION
### Motivation
- Introduce an in-app lightweight UI/UE engineering loop to capture, prioritize and track design/UX issues and experiments.
- Improve mobile navigation and responsive layout so the nav can be toggled on smaller screens and closes on navigation or hash changes.

### Description
- Added a new `UiFeedbackLoop` React component in `frontend/src/UiFeedbackLoop.js` that provides a persistent feedback FAB, a panel to create and manage entries, local persistence via `localStorage` under `ui_ue_loop_v2`, scoring/ranking logic (`calcScore`, `rankItems`), and basic status transitions and archiving.
- Imported and rendered `UiFeedbackLoop` in `App` by updating `frontend/src/App.js`, added `navOpen` state and a mobile toggle button `mobile-nav-toggle`, and ensured navigation and hash changes close the mobile nav by setting `navOpen: false` in the appropriate handlers.
- Expanded `frontend/src/App.css` with styles for the feedback loop UI (`.ui-feedback-loop`, `.feedback-panel`, `.feedback-fab`, list/item styles, status tabs, etc.) and additional responsive/UX tweaks (`.mobile-nav-toggle`, `.App-nav.open`, `.App-content` adjustments, and per-breakpoint rules).
- The feedback panel supports fields for `category`, `priority`, `effort`, `confidence`, and `metric`, and displays KPIs (`total`, `loopRate`) and per-status lists based on `STATUS_OPTIONS`.

### Testing
- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f797ccce288329aa5fb0f902540764)